### PR TITLE
fix: split timestamp by interval before using as an index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "mural-server"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "actix-web",
  "clap",

--- a/src/state.rs
+++ b/src/state.rs
@@ -36,8 +36,10 @@ impl State {
 
         Ok(wallpapers
             .get(
-                std::convert::TryInto::<usize>::try_into(timestamp % wallpapers.len() as u64)
-                    .expect("would only fail when there are a huge number of wallpapers"),
+                std::convert::TryInto::<usize>::try_into(
+                    (timestamp / self.interval) % wallpapers.len() as u64,
+                )
+                .expect("would only fail when there are a huge number of wallpapers"),
             )
             .expect("index should always be in range"))
     }


### PR DESCRIPTION
Fixes #20 